### PR TITLE
Issue-14

### DIFF
--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -5,5 +5,4 @@ class GithubRepo
     @name = repo_info[:name]
     @url = repo_info[:html_url]
   end
-
-end 
+end

--- a/app/models/github_search.rb
+++ b/app/models/github_search.rb
@@ -1,12 +1,11 @@
 class GithubSearch
-
   def repos(token)
     service.get_repos(token).map do |data|
       GithubRepo.new(data)
     end
-  end 
+  end
 
   def service
     GithubService.new
-  end 
-end 
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,16 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   enum role: { default: 0, admin: 1 }
   has_secure_password
+
+  def user_repos(count = 50)
+    search = GithubSearch.new
+    repos = search.repos(github_token) if github_token
+    return nil if !repos
+    repos[0...count]
+  end
+  
+  def has_repos?
+    return true if user_repos
+    return false
+  end 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,11 @@ class User < ApplicationRecord
     search = GithubSearch.new
     repos = search.repos(github_token) if github_token
     return nil if !repos
+
     repos[0...count]
   end
-  
+
   def has_repos?
-    return true if user_repos
-    return false
-  end 
+    user_repos != nil
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,16 +1,15 @@
 class GithubService
-
   def get_repos(github_token)
-    params = {sort: "created", direction: "desc"}
+    params = { sort: 'created', direction: 'desc' }
 
-    get_json('user/repos', params, github_token)
-  end 
+    get_json('user/repos', github_token, params)
+  end
 
   private
 
-  def get_json(url, params = nil, github_token)
+  def get_json(url, github_token, params = nil)
     response = conn.get(url, params) do |repo|
-      repo.headers["Authorization"] = "token #{github_token}"
+      repo.headers['Authorization'] = "token #{github_token}"
     end
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,8 +14,8 @@
     <% if current_user.github_token %>
       <h1>Github Repositories</h1>
       <% current_user.user_repos(5).each do |repo| %>
-        <section id="repo-<%= repo.name %>">
-          <%= link_to "#{repo.name}", "#{repo.url}" %><br>
+        <section class="repo">
+          <%= link_to "#{repo.name}", "#{repo.url}", class: "repo-link" %><br>
         </section>
       <% end %>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,4 +10,14 @@
   <section>
     <h1>Bookmarked Segments</h1>
   </section>
+  <section class="github">
+    <% if current_user.github_token %>
+      <h1>Github Repositories</h1>
+      <% current_user.user_repos(5).each do |repo| %>
+        <section id="repo-<%= repo.name %>">
+          <%= link_to "#{repo.name}", "#{repo.url}" %><br>
+        </section>
+      <% end %>
+    <% end %>
+  </section>
 </section>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     last_name { Faker::Artist.name }
     password { Faker::Color.color_name }
     role { :default }
+    github_token { ENV["GITHUB_API_KEY"] }
   end
 
   factory :admin, parent: :user do

--- a/spec/features/user/user_dashboard_spec.rb
+++ b/spec/features/user/user_dashboard_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'user dashboard show page', type: :feature do
+  describe 'As a user' do
+    before(:each) do
+
+      user = create(:user)
+      repos = user.user_repos(5)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+    end
+
+    it "page has Github section" do
+      expect(page).to have_css(".github")
+      expect(page).to have_content("Github Repositories")
+    end
+
+    xit "can see the name of five of my repositories with links to their repos on github" do
+      within("#order-#{@order1.id}") do
+        expect(page).to have_link("Order #{@order11.id}")
+      end
+    end
+  end 
+end 

--- a/spec/features/user/user_dashboard_spec.rb
+++ b/spec/features/user/user_dashboard_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'user dashboard show page', type: :feature do
     before(:each) do
 
       user = create(:user)
-      repos = user.user_repos(5)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -17,9 +16,12 @@ RSpec.describe 'user dashboard show page', type: :feature do
       expect(page).to have_content("Github Repositories")
     end
 
-    xit "can see the name of five of my repositories with links to their repos on github" do
-      within("#order-#{@order1.id}") do
-        expect(page).to have_link("Order #{@order11.id}")
+    it "can see the name of five of my repositories with links to their repos on github" do
+      within(".github") do
+        expect(page).to have_css(".repo", count: 5)
+        within(first(".repo")) do
+          expect(page).to have_css(".repo-link")
+        end 
       end
     end
   end 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe User, type: :model do
       expect(admin.admin?).to be_truthy
     end
   end
+  describe 'instance_methods' do
+    it 'user_repos' do
+      user1 = create(:user)
+      user2 = create(:user, github_token: nil)
+
+      expect(user1.user_repos(5).count).to eq(5)
+      expect(user1.user_repos(5).first).to be_a(GithubRepo) 
+
+      expect(user2.user_repos(5)).to eq(nil)
+    end
+    it 'has_repos?' do
+      user1 = create(:user)
+      user2 = create(:user, github_token: nil)
+
+      expect(user1.has_repos?).to eq(true)
+      expect(user2.has_repos?).to eq(false)
+    end
+  end
 end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -6,8 +6,9 @@ describe 'Github API' do
     github = GithubService.new
     repos = github.get_repos(token)
 
-
-    expect(repos.first[:name]).to eq("brownfield-of-dreams")
-    expect(repos.count).to eq(30)
+    
+    expect(repos).to be_a(Array)
+    expect(repos.first).to have_key(:name)
+    expect(repos.first).to have_key(:html_url)
   end
 end


### PR DESCRIPTION
 ## Spec/Features ##
* User dashboard now displays five of the logged-in user's github repos ordered by creation date (newest first)

## Controllers ## 
* No changes to the `users_controller`. Added user model method `user_repos(count)` that finds all repos for that user so that we can call the method off of `current_user`

## Views ##
* Add `github` section to user dashboard view that displays the user's followers
